### PR TITLE
fix: present alertController fix

### DIFF
--- a/UIAlertController+Blocks.m
+++ b/UIAlertController+Blocks.m
@@ -93,7 +93,9 @@ static NSInteger const UIAlertControllerBlocksFirstOtherButtonIndex = 2;
     }
 #endif
     
-    [viewController presentViewController:controller animated:YES completion:nil];
+    [viewController.presentedViewController ?: viewController presentViewController:controller
+                                                                           animated:YES
+                                                                         completion:nil];
     
     return controller;
 }


### PR DESCRIPTION
If `viewController` has presented view controller, then `UIAlertController` won't be presented due to window hierarchy.
